### PR TITLE
Changed the param name for slam_toolbox launch file

### DIFF
--- a/go2_robot_sdk/launch/robot.launch.py
+++ b/go2_robot_sdk/launch/robot.launch.py
@@ -236,7 +236,7 @@ def generate_launch_description():
                     'slam_toolbox'), 'launch', 'online_async_launch.py')
             ]),
             launch_arguments={
-                'params_file': slam_toolbox_config,
+                'slam_params_file': slam_toolbox_config,
                 'use_sim_time': use_sim_time,
             }.items(),
         ),


### PR DESCRIPTION
The param name for slam_toolbox's configuration file has been changed in slam_toolbox's launch script. See [launch/online_async_launch.py](https://github.com/SteveMacenski/slam_toolbox/blob/humble/launch/online_async_launch.py)