### PR TITLE
Support for custom WebRTC messages over ROS2 topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,20 @@ sudo snap install foxglove-studio
 1. Open Foxglove Studio and press "Open Connection".
 2. In the "Open Connection" settings, choose "Foxglove WebSocket" and use the default configuration ws://localhost:8765, then press "Open".
 
+## WebRTC Topic Interface
+
+The SDK provides a WebRTC topic interface that allows sending various commands to the robot. This is particularly useful for non-movement actions such as turning on headlights, playing sounds, and other robot control functions.
+
+To send commands via the WebRTC topic:
+
+```bash
+# Basic command structure
+ros2 topic pub /webrtc_req unitree_go/msg/WebRtcReq "{api_id: <API_ID>, parameter: '<PARAMETER>', topic: '<TOPIC>', priority: <0|1>}" --once
+
+# Example: Send a handshake command
+ros2 topic pub /webrtc_req unitree_go/msg/WebRtcReq "{api_id: 1016, topic: 'rt/api/sport/request'}" --once
+```
+
 ## WSL 2
 
 If you are running ROS2 under WSL2 - you may need to configure Joystick\Gamepad to navigate the robot.

--- a/go2_robot_sdk/go2_robot_sdk/go2_driver_node.py
+++ b/go2_robot_sdk/go2_robot_sdk/go2_driver_node.py
@@ -114,7 +114,6 @@ class RobotBaseNode(Node):
         self.img_pub = []
         self.camera_info_pub = []
         self.voxel_pub = []
-        self.webrtc_msgs = asyncio.Queue()
 
         if self.conn_mode == 'single':
             self.joint_pub.append(self.create_publisher(
@@ -189,6 +188,7 @@ class RobotBaseNode(Node):
         self.robot_low_cmd = {}
         self.robot_sport_state = {}
         self.robot_lidar = {}
+        self.webrtc_msgs = asyncio.Queue()
 
         self.joy_state = Joy()
 

--- a/go2_robot_sdk/scripts/go2_func.py
+++ b/go2_robot_sdk/scripts/go2_func.py
@@ -24,54 +24,46 @@
 import datetime
 import json
 import random
+from typing import Any, Dict, Optional
+
+SPORT_MODE_TOPIC = "rt/api/sport/request"
 
 
-def generate_id():
+def generate_id() -> int:
     return int(datetime.datetime.now().timestamp() * 1000 % 2147483648) + random.randint(0, 999)
 
 
-def gen_command(cmd: int):
-    command = {
+def create_command_structure(api_id: int, parameter: Any, topic: str = SPORT_MODE_TOPIC) -> Dict:
+    return {
         "type": "msg",
-                "topic": "rt/api/sport/request",
-                "data": {
-                    "header":
-                        {
-                            "identity":
-                                {
-                                    "id": generate_id(),
-                                    "api_id": cmd
-                                }
-                        },
-                    "parameter": json.dumps(cmd)
-                }
-    }
-    command = json.dumps(command)
-    return command
-
-
-def gen_mov_command(x: float, y: float, z: float):
-
-    command = {
-        "type": "msg",
-        "topic": "rt/api/sport/request",
+        "topic": topic,
         "data": {
-            "header":
-                {
-                    "identity":
-                        {
-                            "id": generate_id(),
-                            "api_id": 1008
-                        }
-                },
-            "parameter": json.dumps(
-                {
-                    "x": x,
-                    "y": y,
-                    "z": z
-                })
-
+            "header": {
+                "identity": {
+                    "id": generate_id(),
+                    "api_id": api_id
+                }
+            },
+            "parameter": json.dumps(parameter)
         }
     }
-    command = json.dumps(command)
-    return command
+
+
+def gen_command(cmd: int, parameters: Optional[Any] = None, topic: Optional[str] = None) -> str:
+    parameter = parameters if parameters is not None else cmd
+    command = create_command_structure(
+        api_id=cmd,
+        parameter=parameter,
+        topic=topic or SPORT_MODE_TOPIC
+    )
+    return json.dumps(command)
+
+
+def gen_mov_command(x: float, y: float, z: float) -> str:
+    parameters = {"x": x, "y": y, "z": z}
+    command = create_command_structure(
+        api_id=1008,
+        parameter=parameters,
+        topic=SPORT_MODE_TOPIC
+    )
+    return json.dumps(command)

--- a/unitree_go/CMakeLists.txt
+++ b/unitree_go/CMakeLists.txt
@@ -7,7 +7,6 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 # uncomment the following section in order to fill in
 # further dependencies manually.
@@ -39,9 +38,9 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 "msg/UwbSwitch.msg"
 "msg/VoxelMapCompressed.msg"
 "msg/VoxelHeightMapState.msg"
+"msg/WebRtcReq.msg"
 "msg/WirelessController.msg"
 
-  DEPENDENCIES geometry_msgs # Add packages that above messages depend on, in this case geometry_msgs for Sphere.msg
 )
 
 

--- a/unitree_go/msg/WebRtcReq.msg
+++ b/unitree_go/msg/WebRtcReq.msg
@@ -3,6 +3,6 @@ string topic
 # api_id, see https://wiki.theroboverse.com/en/unitree-go2-app-console-commands#sending-commands-to-go2
 uint16 api_id
 # payload for specific api_id
-string data
+string parameter
 # priority of the message. 0 non-priority, 1 priority
 uint8 priority

--- a/unitree_go/msg/WebRtcReq.msg
+++ b/unitree_go/msg/WebRtcReq.msg
@@ -1,0 +1,8 @@
+# topic name on dog's side including rt/ prefix
+string topic
+# api_id, see https://wiki.theroboverse.com/en/unitree-go2-app-console-commands#sending-commands-to-go2
+uint16 api_id
+# payload for specific api_id
+string data
+# priority of the message. 0 non-priority, 1 priority
+uint8 priority


### PR DESCRIPTION
Relay incoming `api_id`/`topic`/`payload` to the webrtc channels. Makes it easy to call sports API or others via ros2 topics. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgraded remote communication with enhanced WebRTC support for smoother command processing and more reliable message delivery.
  - Introduced a new message structure for WebRTC requests, allowing for more detailed command handling and priority management.
  - Improved command generation that offers clearer and more flexible control over movement and operating modes.
  - Added documentation for the WebRTC topic interface, detailing command structure and usage examples.

- **Chores**
  - Streamlined integration by removing outdated dependencies and standardizing messaging interfaces to boost overall performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->