### PR TITLE
Dockerfiles added and Unitree Go2 1.13 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ The `robot.launch.py` code starts many services/nodes simultaneously, including
 
 When you run `robot.launch.py`, `rviz` will fire up, lidar data will begin to accumulate, the front color camera data will be displayed too (typically after 4 seconds), and your dog will be waiting for commands from your joystick (e.g. a X-box controller). You can then steer the dog through your house, e.g., and collect LIDAR mapping data. 
 
+### Running via Docker
+Can set environment variables beforehand, hardcoded in docker/docker-compose.yaml, or as shown below. 
+```shell
+cd docker
+ROBOT_IP=<ROBOT_IP> CONN_TYPE=<webrtc/cyclonedds> docker-compose up --build
+```
+
 ### SLAM and Nav2
 
 ![Initial Rviz Display](doc_images/slam_nav_map.png)

--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ rosdep install --from-paths src --ignore-src -r -y
 colcon build
 ```
 
+## Running via Docker
+Can set environment variables beforehand, hardcoded in docker/docker-compose.yaml, or as shown below. 
+
+Run:
+```shell
+cd docker
+ROBOT_IP=<ROBOT_IP> CONN_TYPE=<webrtc/cyclonedds> docker-compose up --build
+```
+
 ## Usage
 
 Don't forget to set up your Go2 robot in Wifi-mode and obtain the IP. You can use the mobile app to get it. Go to Device -> Data -> Automatic Machine Inspection and look for STA Network: wlan0.
@@ -125,13 +134,6 @@ The `robot.launch.py` code starts many services/nodes simultaneously, including
 * av2_bringup/navigation_launch.py
 
 When you run `robot.launch.py`, `rviz` will fire up, lidar data will begin to accumulate, the front color camera data will be displayed too (typically after 4 seconds), and your dog will be waiting for commands from your joystick (e.g. a X-box controller). You can then steer the dog through your house, e.g., and collect LIDAR mapping data. 
-
-### Running via Docker
-Can set environment variables beforehand, hardcoded in docker/docker-compose.yaml, or as shown below. 
-```shell
-cd docker
-ROBOT_IP=<ROBOT_IP> CONN_TYPE=<webrtc/cyclonedds> docker-compose up --build
-```
 
 ### SLAM and Nav2
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,101 @@
+FROM ubuntu:22.04
+
+# Avoid prompts from apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set locale
+RUN apt-get update && apt-get install -y locales && \
+    locale-gen en_US en_US.UTF-8 && \
+    update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+
+# Set ROS distro
+ENV ROS_DISTRO=humble
+
+# Install basic requirements
+RUN apt-get update && apt-get install -y \
+    curl \
+    gnupg2 \
+    lsb-release \
+    python3-pip \
+    clang \
+    portaudio19-dev \
+    git \
+    mesa-utils \
+    libgl1-mesa-glx \
+    libgl1-mesa-dri \
+    software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install specific numpy version first
+RUN pip install 'numpy<2.0.0'
+
+# Add ROS2 apt repository
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+# Install ROS2 packages and dependencies
+RUN apt-get update && apt-get install -y \
+    ros-${ROS_DISTRO}-desktop \
+    ros-${ROS_DISTRO}-ros-base \
+    ros-${ROS_DISTRO}-image-tools \
+    ros-${ROS_DISTRO}-vision-msgs \
+    ros-${ROS_DISTRO}-rviz2 \
+    ros-${ROS_DISTRO}-rqt \
+    ros-${ROS_DISTRO}-rqt-common-plugins \
+    ros-${ROS_DISTRO}-twist-mux \
+    ros-${ROS_DISTRO}-joy \
+    ros-${ROS_DISTRO}-teleop-twist-joy \
+    ros-${ROS_DISTRO}-navigation2 \
+    ros-${ROS_DISTRO}-nav2-bringup \
+    ros-${ROS_DISTRO}-nav2-amcl \
+    ros-${ROS_DISTRO}-nav2-map-server \
+    ros-${ROS_DISTRO}-nav2-util \
+    ros-${ROS_DISTRO}-pointcloud-to-laserscan \
+    ros-${ROS_DISTRO}-slam-toolbox \
+    ros-${ROS_DISTRO}-foxglove-bridge \
+    python3-rosdep \
+    python3-rosinstall \
+    python3-rosinstall-generator \
+    python3-wstool \
+    python3-colcon-common-extensions \
+    python3-vcstool \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Initialize rosdep
+RUN rosdep init && rosdep update
+
+# Create workspace
+WORKDIR /ros2_ws
+
+# Clone the repository with submodules
+RUN git clone --recurse-submodules https://github.com/abizovnuralem/go2_ros2_sdk src
+
+# Install Python requirements (with numpy constraint)
+RUN cd src && pip install -r requirements.txt
+
+# Install ROS dependencies
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh && \
+    rosdep install --from-paths src --ignore-src -r -y
+
+# Build the workspace
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh && \
+    colcon build
+
+# Source ROS2 and workspace in bashrc
+RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /root/.bashrc && \
+    echo "source /ros2_ws/install/setup.bash" >> /root/.bashrc
+
+# Set environment variables
+ENV ROBOT_IP=""
+ENV CONN_TYPE="webrtc"
+ENV WEBRTC_SERVER_HOST="0.0.0.0"
+ENV WEBRTC_SERVER_PORT="9991"
+
+# Copy entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["ros2", "launch", "go2_robot_sdk", "robot.launch.py"] 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+
+services:
+  unitree_ros:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - ROBOT_IP=${ROBOT_IP} 
+      - CONN_TYPE=${CONN_TYPE:-webrtc}
+      - WEBRTC_SERVER_HOST=0.0.0.0  # Listen on all interfaces
+      - WEBRTC_SERVER_PORT=${WEBRTC_SERVER_PORT:-9991}
+      - DISPLAY=${DISPLAY:-}  # For GUI applications like rviz2
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix  # X11 forwarding
+      - ${HOME}/.Xauthority:/root/.Xauthority:rw
+    network_mode: "host"  # Required for ROS2 discovery and robot communication
+    privileged: true  # Required for hardware access
+    devices:
+      - /dev/input:/dev/input  # For joystick access
+    restart: unless-stopped 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Source ROS2 environment
+source /opt/ros/${ROS_DISTRO}/setup.bash
+source /ros2_ws/install/setup.bash
+
+# Execute the command passed to docker run
+exec "$@" 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiortc
+aiortc==1.9.0
 aiohttp
 paho-mqtt
 python-dotenv


### PR DESCRIPTION
Tested on Ubuntu 22.04 over WebRTC with an un-jailbroken Unitree Go2. 

Did not test on DDS.

Changes
-  Pinned aiortc to version 1.9.0 to fix 1.13 compatibility error
- Dockerfile
- docker-compose.yaml: CONN_TYPE defaults to webrtc. 
- entrypoint.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added new deployment instructions to run the project via Docker, including guidance for setting environment variables.
- **New Features**
  - Introduced a containerized workflow with integrated service orchestration, enabling streamlined setup for GUI and hardware integration.
- **Chores**
  - Upgraded a key communication dependency to version 1.9.0 and added an image processing dependency for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->