### PR TITLE
Add patch for aioice and aiortc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "go2_robot_sdk/external_lib/aioice"]
-	path = go2_robot_sdk/external_lib/aioice
-	url = https://github.com/legion1581/aioice.git
-	branch = go2

--- a/go2_robot_sdk/go2_robot_sdk/__init__.py
+++ b/go2_robot_sdk/go2_robot_sdk/__init__.py
@@ -20,24 +20,3 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-import sys
-import os
-import logging
-from ament_index_python import get_package_share_directory
-
-logger = logging.getLogger(__name__)
-
-libs_path = os.path.join(
-    get_package_share_directory('go2_robot_sdk'),
-    'external_lib'
-)
-
-if os.path.exists(os.path.join(libs_path, 'aioice', '__init__.py')):
-    sys.path.insert(0, os.path.join(libs_path, 'aioice'))
-    sys.path.insert(0, os.path.join(libs_path))
-
-    logger.info('Patched aioice added to sys.path: {}'.format(sys.path))
-else:
-    logger.error("aioice submodule is not initalized. please init submodules recursively")
-    exit(-1)

--- a/go2_robot_sdk/scripts/webrtc_driver.py
+++ b/go2_robot_sdk/scripts/webrtc_driver.py
@@ -39,6 +39,48 @@ from Crypto.Cipher import PKCS1_v1_5
 import requests
 from aiortc import RTCPeerConnection, RTCSessionDescription
 
+# Monkey-patch aioice.Connection to use a fixed username and password accross all instances.
+
+import aioice
+
+
+class Connection(aioice.Connection):
+    local_username = aioice.utils.random_string(4)
+    local_password = aioice.utils.random_string(22)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.local_username = Connection.local_username
+        self.local_password = Connection.local_password
+
+
+aioice.Connection = Connection  # type: ignore
+
+
+# Monkey-patch aiortc.rtcdtlstransport.X509_DIGEST_ALGORITHMS to remove extra SHA algorithms
+# Extra SHA algorithms introduced in aiortc 1.10.0 causes Unity Go2 to use the new SCTP format, despite aiortc using the old SCTP syntax.
+# This new format is not supported by aiortc version as of today (2025-06-02)
+
+
+import aiortc
+from packaging.version import Version
+
+
+if Version(aiortc.__version__) == Version("1.10.0"):
+    X509_DIGEST_ALGORITHMS = {
+        "sha-256": "SHA256",
+    }
+    aiortc.rtcdtlstransport.X509_DIGEST_ALGORITHMS = X509_DIGEST_ALGORITHMS
+
+elif Version(aiortc.__version__) >= Version("1.11.0"):
+    # Syntax changed in aiortc 1.11.0, so we need to use the hashes module
+    from cryptography.hazmat.primitives import hashes
+
+    X509_DIGEST_ALGORITHMS = {
+        "sha-256": hashes.SHA256(),  # type: ignore
+    }
+    aiortc.rtcdtlstransport.X509_DIGEST_ALGORITHMS = X509_DIGEST_ALGORITHMS
+
 
 from scripts.go2_lidar_decoder import LidarDecoder
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiortc==1.9.0
+aiortc
 aiohttp
 paho-mqtt
 python-dotenv


### PR DESCRIPTION
Monkey-Patch from Dino in Discord, so aioice no longer needs to be included as submodule.

Reference:
https://discord.com/channels/1205243330137690195/1209629104370876508/1379039316336185446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved compatibility for WebRTC connections with Unity Go2 by standardizing credentials and restricting supported security algorithms.
	- Ensured reliable connections by using a fixed username and password and limiting digest algorithms to "sha-256" for enhanced interoperability.
- **Chores**
	- Removed Git submodule configuration for an external library.
	- Eliminated dynamic runtime path adjustments related to the external library.
	- Updated package requirements to allow flexible installation of the WebRTC library version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->