### PR TITLE
Rename teleop_node to go2_teleop_node in config

### DIFF
--- a/go2_robot_sdk/config/twist_mux.yaml
+++ b/go2_robot_sdk/config/twist_mux.yaml
@@ -1,4 +1,4 @@
-/teleop_node:
+/go2_teleop_node:
   ros__parameters:
     axis_linear:
       x: 1


### PR DESCRIPTION
I am not sure if is only on my setup, but I have to change this to make the joystick work