### PR TITLE
Decryption function for webrtc key from new firmware versions

### DIFF
--- a/go2_robot_sdk/go2_robot_sdk/infrastructure/webrtc/go2_connection.py
+++ b/go2_robot_sdk/go2_robot_sdk/infrastructure/webrtc/go2_connection.py
@@ -252,8 +252,9 @@ class Go2Connection:
                 decoded_response = base64.b64decode(response.text).decode('utf-8')
                 decoded_json = json.loads(decoded_response)
                 
-                # Extract the 'data1' field from the JSON
+                # Extract the 'data1' and 'data2' fields from the JSON
                 data1 = decoded_json.get('data1')
+				data2 = decoded_json.get('data2')
                 if not data1:
                     raise Go2ConnectionError("No data1 field in public key response")
 


### PR DESCRIPTION
I added the function that @legion1581 added to his repo https://github.com/legion1581/unitree_webrtc_connect to decrypt the RSA keys being encrypted in the new format in go2 firmware versions 1.1.7+. This solved the webrtc connection issue for me and I believe it should solve the recent issue #211 