### PR TITLE
Fix readme: Update WebRTC command interface to use go2_interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,10 +273,10 @@ To send commands via the WebRTC topic:
 
 ```bash
 # Basic command structure
-ros2 topic pub /webrtc_req unitree_go/msg/WebRtcReq "{api_id: <API_ID>, parameter: '<PARAMETER>', topic: '<TOPIC>', priority: <0|1>}" --once
+ros2 topic pub /webrtc_req go2_interfaces/msg/WebRtcReq "{api_id: <API_ID>, parameter: '<PARAMETER>', topic: '<TOPIC>', priority: <0|1>}" --once
 
 # Example: Send a handshake command
-ros2 topic pub /webrtc_req unitree_go/msg/WebRtcReq "{api_id: 1016, topic: 'rt/api/sport/request'}" --once
+ros2 topic pub /webrtc_req go2_interfaces/msg/WebRtcReq "{api_id: 1016, topic: 'rt/api/sport/request'}" --once
 ```
 
 ## WSL 2


### PR DESCRIPTION
This pull request updates the documentation to reflect a change in the ROS 2 message type used for sending commands via the WebRTC topic. The instructions now reference the correct message type, which will help prevent confusion when publishing commands.

Documentation update:

* In the `README.md`, replaced all instances of `unitree_go/msg/WebRtcReq` with `go2_interfaces/msg/WebRtcReq` in the example commands for sending requests via the WebRTC topic.