### PR TITLE
Support per-device AES-128 key for WebRTC handshake (Go2 firmware >= 1.1.15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,33 @@ export CONN_TYPE="webrtc"
 ros2 launch go2_robot_sdk robot.launch.py
 ```
 
+### Go2 firmware >= 1.1.15 (WebRTC local connection)
+
+Starting with Go2 firmware **1.1.15**, the robot wraps its RSA public key in the LAN handshake (`con_notify`) with a **per-device AES-128 key** (`data2 == 3`) instead of the older static key (`data2 == 2`). If you're on this firmware or newer and see:
+
+```
+Failed to complete encrypted handshake: Failed to load RSA public key: RSA key format is not supported
+```
+
+...you need to supply your robot's per-device AES-128 key via the `aes_key` parameter (or `ROBOT_AES_KEY` / `GO2_AES_KEY` environment variable):
+
+```shell
+export ROBOT_IP="robot_ip"
+export ROBOT_AES_KEY="32_hex_character_key"
+export CONN_TYPE="webrtc"
+ros2 launch go2_robot_sdk robot.launch.py
+```
+
+You can fetch this key with your Unitree account credentials using [`unitree_webrtc_connect`](https://github.com/legion1581/unitree_webrtc_connect)'s `fetch_aes_key.py` example or the `unitree-fetch-aes-key` CLI:
+
+```shell
+pip install unitree_webrtc_connect
+unitree-fetch-aes-key --email your@email.com --password 'yourpassword' --device-type Go2
+```
+
+This prints the AES-128 key (32 hex characters) for each robot registered to your account, keyed by serial number. If your robot is still on older firmware (`data2 == 2` or unencrypted), `aes_key` can be left unset.
+
+
 The `robot.launch.py` code starts many services/nodes simultaneously, including 
 
 * robot_state_publisher

--- a/go2_robot_sdk/go2_robot_sdk/domain/entities/robot_config.py
+++ b/go2_robot_sdk/go2_robot_sdk/domain/entities/robot_config.py
@@ -10,6 +10,7 @@ class RobotConfig:
     """Robot configuration parameters"""
     robot_ip_list: List[str]
     token: str
+    aes_key: str
     conn_type: str
     enable_video: bool
     decode_lidar: bool
@@ -20,7 +21,8 @@ class RobotConfig:
     @classmethod
     def from_params(cls, robot_ip: str, token: str, conn_type: str, 
                    enable_video: bool, decode_lidar: bool, 
-                   publish_raw_voxel: bool, obstacle_avoidance: bool):
+                   publish_raw_voxel: bool, obstacle_avoidance: bool,
+                   aes_key: str = ""):
         """Создание конфигурации из параметров"""
         robot_ip_list = robot_ip.replace(" ", "").split(",")
         conn_mode = "single" if (
@@ -29,6 +31,7 @@ class RobotConfig:
         return cls(
             robot_ip_list=robot_ip_list,
             token=token,
+            aes_key=aes_key,
             conn_type=conn_type,
             enable_video=enable_video,
             decode_lidar=decode_lidar,

--- a/go2_robot_sdk/go2_robot_sdk/infrastructure/webrtc/go2_connection.py
+++ b/go2_robot_sdk/go2_robot_sdk/infrastructure/webrtc/go2_connection.py
@@ -37,6 +37,7 @@ class Go2Connection:
         robot_ip: str,
         robot_num: int,
         token: str = "",
+        aes_key: str = "",
         on_validated: Optional[Callable] = None,
         on_message: Optional[Callable] = None,
         on_open: Optional[Callable] = None,
@@ -47,6 +48,7 @@ class Go2Connection:
         self.robot_ip = robot_ip
         self.robot_num = str(robot_num)
         self.token = token
+        self.aes_key = aes_key
         self.robot_validation = "PENDING"
         self.validation_result = "PENDING"
         
@@ -221,7 +223,38 @@ class Go2Connection:
         aesgcm = AESGCM(key) 
         plaintext = aesgcm.decrypt(nonce, ciphertext + tag, None)
         return plaintext.decode('utf-8')
-	 
+
+    #decrypt RSA key from firmware version >=1.1.15 (data2=3), wrapped with a
+    #per-device AES-128 key fetched from the Unitree cloud account
+    def decrypt_con_notify_data_v3(self, encrypted_b64: str) -> str:
+        if not self.aes_key:
+            raise EncryptionError(
+                "Robot requires a per-device AES-128 key (data2=3, firmware "
+                ">=1.1.15) but none was provided. Set the 'aes_key' robot "
+                "config parameter (32 hex chars)."
+            )
+        try:
+            key = bytes.fromhex(self.aes_key.strip().lower())
+        except ValueError as e:
+            raise EncryptionError(f"aes_key is not valid hex: {e}")
+        if len(key) != 16:
+            raise EncryptionError(
+                f"aes_key must be 16 bytes (32 hex chars), got {len(key)} bytes"
+            )
+
+        data = base64.b64decode(encrypted_b64)
+        if len(data) < 28:
+            raise ValueError("Decryption failed: input data too short")
+        tag = data[-16:]
+        nonce = data[-28:-16]
+        ciphertext = data[:-28]
+
+        aesgcm = AESGCM(key)
+        try:
+            plaintext = aesgcm.decrypt(nonce, ciphertext + tag, None)
+        except Exception as e:
+            raise EncryptionError(f"aes_key rejected by robot: {e}")
+        return plaintext.decode('utf-8')
 
     async def connect(self) -> None:
         """Establish WebRTC connection to robot with full encryption"""
@@ -260,6 +293,8 @@ class Go2Connection:
 
                 if data2 == 2:
                     data1 = self.decrypt_con_notify_data(data1)
+                elif data2 == 3:
+                    data1 = self.decrypt_con_notify_data_v3(data1)
                 # Extract the public key from 'data1'
                 public_key_pem = data1[10:len(data1)-10]
                 path_ending = PathCalculator.calc_local_path_ending(data1)

--- a/go2_robot_sdk/go2_robot_sdk/infrastructure/webrtc/webrtc_adapter.py
+++ b/go2_robot_sdk/go2_robot_sdk/infrastructure/webrtc/webrtc_adapter.py
@@ -44,6 +44,7 @@ class WebRTCAdapter(IRobotDataReceiver, IRobotController):
                 robot_ip=robot_ip,
                 robot_num=robot_id,
                 token=self.config.token,
+                aes_key=self.config.aes_key,
                 on_validated=self._on_validated,
                 on_message=self._on_data_channel_message,
                 on_video_frame=self.on_video_frame_callback if self.config.enable_video else None,

--- a/go2_robot_sdk/go2_robot_sdk/presentation/go2_driver_node.py
+++ b/go2_robot_sdk/go2_robot_sdk/presentation/go2_driver_node.py
@@ -78,6 +78,7 @@ class Go2DriverNode(Node):
         """Configuration setup"""
         robot_ip = os.getenv('ROBOT_IP', os.getenv('GO2_IP', ''))
         token = os.getenv('ROBOT_TOKEN', os.getenv('GO2_TOKEN', ''))
+        aes_key = os.getenv('ROBOT_AES_KEY', os.getenv('GO2_AES_KEY', ''))
         conn_type = os.getenv('CONN_TYPE', '')
 
         # Declare parameters
@@ -86,6 +87,7 @@ class Go2DriverNode(Node):
             parameters=[
                 ('robot_ip', robot_ip),
                 ('token', token),
+                ('aes_key', aes_key),
                 ('conn_type', conn_type),
                 ('enable_video', True),
                 ('decode_lidar', True),
@@ -100,6 +102,7 @@ class Go2DriverNode(Node):
         config = RobotConfig.from_params(
             robot_ip=self.get_parameter('robot_ip').get_parameter_value().string_value,
             token=self.get_parameter('token').get_parameter_value().string_value,
+            aes_key=self.get_parameter('aes_key').get_parameter_value().string_value,
             conn_type=self.get_parameter('conn_type').get_parameter_value().string_value,
             enable_video=self.get_parameter('enable_video').get_parameter_value().bool_value,
             decode_lidar=self.get_parameter('decode_lidar').get_parameter_value().bool_value,


### PR DESCRIPTION

## Summary

Fixes #238

Go2 firmware >= 1.1.15 wraps the RSA public key in the LAN handshake with a per-device AES-128 key (`data2 == 3`), which wasn't handled before (only `data2 == 2`, the static key case, was supported). This caused:

```
Failed to load RSA public key: RSA key format is not supported
```

This PR adds a `data2 == 3` branch that decrypts using an optional `aes_key` (env var `ROBOT_AES_KEY` / `GO2_AES_KEY`, same pattern as `token`). No new dependencies — reuses the `AESGCM` import already used for `data2 == 2`.

Backward compatible: `aes_key` defaults to empty and only applies when the robot reports `data2 == 3`.

Tested on a Go2 EDU on firmware 1.15 — fails without `aes_key`, connects normally with it set.

## References

- Fixes #238
- Builds on the static-key (`data2 == 2`) support added in #212
- AES-GCM decrypt logic modeled after [`legion1581/unitree_webrtc_connect`](https://github.com/legion1581/unitree_webrtc_connect)'s `_decrypt_data1_v3` in [`unitree_auth.py`](https://github.com/legion1581/unitree_webrtc_connect/blob/master/unitree_webrtc_connect/unitree_auth.py)