### PR TITLE
Publish battery state from the lowstate BMS

### DIFF
--- a/go2_robot_sdk/go2_robot_sdk/application/services/robot_data_service.py
+++ b/go2_robot_sdk/go2_robot_sdk/application/services/robot_data_service.py
@@ -5,7 +5,7 @@ import logging
 import math
 from typing import Dict, Any
 
-from ...domain.entities import RobotData, RobotState, IMUData, OdometryData, JointData, LidarData
+from ...domain.entities import RobotData, RobotState, IMUData, OdometryData, JointData, LidarData, BatteryData
 from ...domain.interfaces import IRobotDataPublisher
 from ...domain.constants import RTC_TOPIC
 
@@ -40,6 +40,7 @@ class RobotDataService:
             elif topic == RTC_TOPIC["LOW_STATE"]:
                 self._process_low_state(msg, robot_data)
                 self.publisher.publish_joint_state(robot_data)
+                self.publisher.publish_battery_state(robot_data)
 
         except Exception as e:
             logger.error(f"Error processing WebRTC message: {e}")
@@ -140,6 +141,19 @@ class RobotDataService:
             robot_data.joint_data = JointData(
                 motor_state=low_state_data['motor_state']
             )
+
+            # The same lowstate packet carries the BMS. Guarded because it is
+            # the only consumer of this sub-struct: a firmware that omits it
+            # must not take joint states down with it.
+            bms = low_state_data.get('bms_state')
+            if bms and bms.get('soc') is not None:
+                robot_data.battery_data = BatteryData(
+                    soc=bms['soc'],
+                    current=bms.get('current'),
+                    cycle=bms.get('cycle'),
+                    temperatures=(list(bms.get('bq_ntc') or [])
+                                  + list(bms.get('mcu_ntc') or [])) or None,
+                )
         except Exception as e:
             logger.error(f"Error processing low state: {e}")
 

--- a/go2_robot_sdk/go2_robot_sdk/domain/entities/__init__.py
+++ b/go2_robot_sdk/go2_robot_sdk/domain/entities/__init__.py
@@ -1,7 +1,7 @@
 """
 Domain entities - core business entities of the system
 """
-from .robot_data import RobotData, RobotState, LidarData, CameraData, IMUData, OdometryData, JointData
+from .robot_data import RobotData, RobotState, LidarData, CameraData, IMUData, OdometryData, JointData, BatteryData
 from .robot_config import RobotConfig
 
-__all__ = ['RobotData', 'RobotState', 'LidarData', 'CameraData', 'IMUData', 'OdometryData', 'JointData', 'RobotConfig'] 
+__all__ = ['RobotData', 'RobotState', 'LidarData', 'CameraData', 'IMUData', 'OdometryData', 'JointData', 'BatteryData', 'RobotConfig'] 

--- a/go2_robot_sdk/go2_robot_sdk/domain/entities/robot_data.py
+++ b/go2_robot_sdk/go2_robot_sdk/domain/entities/robot_data.py
@@ -45,6 +45,15 @@ class JointData:
 
 
 @dataclass
+class BatteryData:
+    """Battery / BMS state, as reported by the robot"""
+    soc: int  # state of charge, percent (0-100)
+    current: Optional[int] = None  # mA, negative while discharging
+    cycle: Optional[int] = None  # charge cycles
+    temperatures: Optional[List[int]] = None  # BQ/MCU NTC probes, degC
+
+
+@dataclass
 class LidarData:
     """LiDAR sensor data"""
     positions: np.ndarray
@@ -75,5 +84,6 @@ class RobotData:
     imu_data: Optional[IMUData] = None
     odometry_data: Optional[OdometryData] = None
     joint_data: Optional[JointData] = None
+    battery_data: Optional[BatteryData] = None
     lidar_data: Optional[LidarData] = None
     camera_data: Optional[CameraData] = None 

--- a/go2_robot_sdk/go2_robot_sdk/domain/interfaces/robot_data_publisher.py
+++ b/go2_robot_sdk/go2_robot_sdk/domain/interfaces/robot_data_publisher.py
@@ -19,6 +19,11 @@ class IRobotDataPublisher(ABC):
         pass
 
     @abstractmethod
+    def publish_battery_state(self, robot_data: RobotData) -> None:
+        """Publish battery state"""
+        pass
+
+    @abstractmethod
     def publish_robot_state(self, robot_data: RobotData) -> None:
         """Publish robot state and IMU data"""
         pass

--- a/go2_robot_sdk/go2_robot_sdk/infrastructure/ros2/ros2_publisher.py
+++ b/go2_robot_sdk/go2_robot_sdk/infrastructure/ros2/ros2_publisher.py
@@ -9,7 +9,7 @@ from tf2_ros import TransformBroadcaster
 from geometry_msgs.msg import TransformStamped
 from go2_interfaces.msg import Go2State, IMU
 from go2_interfaces.msg import VoxelMapCompressed
-from sensor_msgs.msg import PointCloud2, PointField, JointState
+from sensor_msgs.msg import BatteryState, PointCloud2, PointField, JointState
 from sensor_msgs_py import point_cloud2
 from std_msgs.msg import Header
 from nav_msgs.msg import Odometry
@@ -100,6 +100,33 @@ class ROS2Publisher(IRobotDataPublisher):
         odom_msg.pose.pose.orientation.w = float(orientation['w'])
 
         self.publishers['odometry'][robot_idx].publish(odom_msg)
+
+    def publish_battery_state(self, robot_data: RobotData) -> None:
+        """Publish battery state"""
+        if not robot_data.battery_data:
+            return
+
+        try:
+            robot_idx = int(robot_data.robot_id)
+            battery = robot_data.battery_data
+
+            msg = BatteryState()
+            msg.header.stamp = self.node.get_clock().now().to_msg()
+            # BatteryState.percentage is 0.0-1.0; the BMS reports 0-100.
+            msg.percentage = float(battery.soc) / 100.0
+            msg.power_supply_status = BatteryState.POWER_SUPPLY_STATUS_UNKNOWN
+            msg.power_supply_health = BatteryState.POWER_SUPPLY_HEALTH_UNKNOWN
+            msg.power_supply_technology = BatteryState.POWER_SUPPLY_TECHNOLOGY_LION
+            msg.present = True
+            if battery.current is not None:
+                # BMS reports mA (negative while discharging); ROS wants A.
+                msg.current = float(battery.current) / 1000.0
+            if battery.temperatures:
+                msg.temperature = float(max(battery.temperatures))
+
+            self.publishers['battery'][robot_idx].publish(msg)
+        except Exception as e:
+            logger.error(f"Error publishing battery state: {e}")
 
     def publish_joint_state(self, robot_data: RobotData) -> None:
         """Publish joint state data"""

--- a/go2_robot_sdk/go2_robot_sdk/presentation/go2_driver_node.py
+++ b/go2_robot_sdk/go2_robot_sdk/presentation/go2_driver_node.py
@@ -18,7 +18,7 @@ from tf2_ros import TransformBroadcaster
 from geometry_msgs.msg import Twist, PoseStamped
 from go2_interfaces.msg import Go2State, IMU
 from go2_interfaces.msg import LowState, VoxelMapCompressed, WebRtcReq
-from sensor_msgs.msg import PointCloud2, JointState, Joy, Image, CameraInfo
+from sensor_msgs.msg import BatteryState, PointCloud2, JointState, Joy, Image, CameraInfo
 from nav_msgs.msg import Odometry
 
 from ..domain.entities import RobotConfig, RobotData, CameraData
@@ -133,6 +133,7 @@ class Go2DriverNode(Node):
         publishers = {
             'joint_state': [],
             'robot_state': [],
+            'battery': [],
             'lidar': [],
             'odometry': [],
             'imu': [],
@@ -153,6 +154,7 @@ class Go2DriverNode(Node):
                 imu_topic = 'imu'
                 camera_topic = 'camera/image_raw'
                 camera_info_topic = 'camera/camera_info'
+                battery_topic = 'battery'
                 voxel_topic = '/utlidar/voxel_map_compressed'
             else:
                 prefix = f'robot{i}'
@@ -163,6 +165,7 @@ class Go2DriverNode(Node):
                 imu_topic = f'{prefix}/imu'
                 camera_topic = f'{prefix}/camera/image_raw'
                 camera_info_topic = f'{prefix}/camera/camera_info'
+                battery_topic = f'{prefix}/battery'
                 voxel_topic = f'{prefix}/utlidar/voxel_map_compressed'
 
             # Create publishers
@@ -170,6 +173,8 @@ class Go2DriverNode(Node):
                 self.create_publisher(JointState, joint_topic, qos_profile))
             publishers['robot_state'].append(
                 self.create_publisher(Go2State, robot_state_topic, qos_profile))
+            publishers['battery'].append(
+                self.create_publisher(BatteryState, battery_topic, qos_profile))
             publishers['lidar'].append(
                 self.create_publisher(
                     PointCloud2, lidar_topic, best_effort_qos,


### PR DESCRIPTION
The robot already sends its battery, and the driver throws it away.

`rt/lf/lowstate` carries a `bms_state` — state of charge, current, cycles, NTC probes — the same struct that `go2_interfaces/LowState.msg` already declares. But `_process_low_state` reads only `motor_state` from that packet and drops the rest, so **in WebRTC mode no ROS topic exposes the battery at all**.

There is no way to work around this downstream: `webrtc_req` is one-way, and the robot accepts a single WebRTC session, so a second node cannot subscribe to the data either. The information reaches the onboard computer and is discarded three lines from where it could be published.

### What this does

Publishes `sensor_msgs/BatteryState` on `battery` (`robot<N>/battery` in multi-robot mode), following the existing layering:

- `BatteryData` entity in `domain/entities`
- `publish_battery_state` on `IRobotDataPublisher`
- implementation in the ROS2 adapter, publisher created in the driver node

Unit conversions follow the ROS conventions: `percentage` is normalised to 0.0–1.0 (the BMS reports 0–100) and `current` from mA to A.

The BMS read is **guarded** — this is the only consumer of that sub-struct, and a firmware that omits it should not take joint states down with it.

### Status: draft, pending hardware validation

Marked as draft for one reason I want to be upfront about: I derived the payload key (`bms_state`, with `soc` inside) from `LowState.msg` in this repo and from the sibling `motor_state` access right above it, but **I have not yet confirmed it against a live robot**. If the key differs on the wire, the guard makes it a no-op rather than a crash, and I will push a fix.

I will validate on our Go2 Pro and take it out of draft. Happy to adjust naming or topic placement if you prefer something else.

### Motivation

On a substation inspection our operator had no battery reading at all and had to guess the remaining range.